### PR TITLE
Update retry options to use limit instead of retries

### DIFF
--- a/guides/initialise-sdk.md
+++ b/guides/initialise-sdk.md
@@ -54,7 +54,7 @@ import { init } from "@digime/digime-sdk-nodejs";
 const sdk = init({
     applicationId: <my-unique-application-id>,
     retryOptions: {
-        retries: 10,
+        limit: 10,
     }
 });
 ```

--- a/src/init.ts
+++ b/src/init.ts
@@ -43,13 +43,14 @@ import {
     GetUserStorageOptions,
     getUserStorage,
 } from "./storage";
+import type { RetryOptions } from "./types/retry-options";
 
 const CLOUD_BASE_URL = "https://cloud.digi.me/v1/";
 const DEFAULT_BASE_URL = "https://api.digi.me/v1.7/";
 const DEFAULT_ONBOARD_URL = "https://api.digi.me/apps/saas/";
 const DEFAULT_RETRIES_OPTIONS = {
-    retries: 5,
-};
+    limit: 2,
+} satisfies RetryOptions;
 
 const init = (config: SDKConfiguration): DigimeSDK => {
     if (!isPlainObject(config)) {

--- a/src/read-file.spec.ts
+++ b/src/read-file.spec.ts
@@ -1,0 +1,87 @@
+/*!
+ * Copyright (c) 2009-2024 World Data Exchange Holdings Pty Limited (WDXH). All rights reserved.
+ */
+
+import nock from "nock";
+import NodeRSA from "node-rsa";
+import * as SDK from ".";
+import { SAMPLE_TOKEN, TEST_CUSTOM_BASE_URL, TEST_CUSTOM_ONBOARD_URL } from "../utils/test-constants";
+import { ContractDetails } from "./types/common";
+import { FailableJunkStream, createTestServer, fileContentToCAFormat, loadScopeDefinitions } from "../utils/test-utils";
+import { Readable } from "node:stream";
+
+const customSDK = SDK.init({
+    applicationId: "test-application-id",
+    baseUrl: "http://localhost:3999/v1.7/",
+    onboardUrl: TEST_CUSTOM_ONBOARD_URL,
+    retryOptions: {
+        errorCodes: ["ECONNRESET"],
+    },
+});
+
+const testKeyPair: NodeRSA = new NodeRSA({ b: 2048 });
+
+beforeEach(() => {
+    nock.cleanAll();
+});
+
+const CONTRACT_DETAILS: ContractDetails = {
+    contractId: "test-contract-id",
+    privateKey: testKeyPair.exportKey("pkcs1-private-pem").toString(),
+};
+
+describe.each<[string, ReturnType<typeof SDK.init>, string]>([["Custom SDK", customSDK, TEST_CUSTOM_BASE_URL]])(
+    "%s",
+    (_title, sdk, baseUrl) => {
+        it("retries when request is aborted", async () => {
+            expect.assertions(1);
+
+            let failedOnce = false;
+
+            const server = await createTestServer(3999, (_req, res) => {
+                const fileDefs = loadScopeDefinitions(
+                    "fixtures/network/get-file/valid-files.json",
+                    `${new URL(baseUrl).origin}`
+                );
+
+                const caFormatted = fileContentToCAFormat(fileDefs, testKeyPair);
+
+                const responseStream = failedOnce
+                    ? Readable.from(
+                          caFormatted[0].response instanceof Buffer ? caFormatted[0].response : Buffer.from("test")
+                      )
+                    : new FailableJunkStream(10, 5);
+                if (!failedOnce) {
+                    failedOnce = true;
+                }
+                res.setHeader("Content-Type", "application/octet-stream");
+                res.setHeader("x-metadata", (caFormatted[0].rawHeaders as Record<string, string>)?.["x-metadata"]);
+                responseStream.on("error", () => {
+                    if (res.socket) {
+                        res.socket.destroy();
+                    }
+                });
+                responseStream.pipe(res);
+            });
+
+            const sessionKey = "test-session-key";
+
+            const fileName = "test-file";
+
+            const promise = sdk.readFile({
+                privateKey: CONTRACT_DETAILS.privateKey,
+                userAccessToken: SAMPLE_TOKEN,
+                sessionKey,
+                contractId: CONTRACT_DETAILS.contractId,
+                fileName,
+            });
+
+            await expect(promise).resolves.toMatchObject({
+                fileData: expect.any(Buffer),
+                fileName: expect.any(String),
+            });
+
+            server.close();
+        }, 1000000);
+    }
+);

--- a/src/read-file.ts
+++ b/src/read-file.ts
@@ -83,6 +83,7 @@ const fetchFile = async (options: ReadFileOptionsFormated, sdkConfig: SDKConfigu
             accept: "application/octet-stream",
         },
         responseType: "buffer",
+        retry: sdkConfig.retryOptions,
         hooks: {
             beforeRequest: [
                 (options) => {

--- a/src/types/retry-options.spec.ts
+++ b/src/types/retry-options.spec.ts
@@ -27,7 +27,6 @@ const VALID_HTTP_METHODS = [
 describe("isRetryOptions", () => {
     it("Returns true when given all RetryOptions properties", async () => {
         const config = {
-            retries: 2,
             limit: 4,
             methods: ["GET"],
             statusCodes: [200],
@@ -63,15 +62,6 @@ describe("isRetryOptions", () => {
     describe("Returns false when given a non-object", () => {
         it.each([true, false, null, undefined, [], 0, NaN, "", () => null, Symbol("test")])("%p", (value) => {
             const actual = isRetryOptions(value);
-            expect(actual).toBe(false);
-        });
-    });
-
-    describe("Returns false when the retries property of the retryOptions object is not a number", () => {
-        it.each([true, false, null, [], "", {}, () => null, Symbol("test")])("%p", (value) => {
-            const actual = isRetryOptions({
-                retries: value,
-            });
             expect(actual).toBe(false);
         });
     });
@@ -143,7 +133,6 @@ describe("isRetryOptions", () => {
 describe("assertIsRetryOptions", () => {
     it("Does not throw when given all RetryOptions properties", async () => {
         const config = {
-            retries: 2,
             limit: 4,
             methods: ["GET"],
             statusCodes: [200],
@@ -172,16 +161,6 @@ describe("assertIsRetryOptions", () => {
     describe("Throws TypeValidationError when given a non-object", () => {
         it.each([true, false, null, undefined, [], 0, NaN, "", () => null, Symbol("test")])("%p", (value) => {
             const actual = () => assertIsRetryOptions(value);
-            expect(actual).toThrow(TypeValidationError);
-        });
-    });
-
-    describe("Throws TypeValidationError when the retries property of the retryOptions object is not a number", () => {
-        it.each([true, false, null, [], {}, "", () => null, Symbol("test")])("%p", (value) => {
-            const actual = () =>
-                assertIsRetryOptions({
-                    retries: value,
-                });
             expect(actual).toThrow(TypeValidationError);
         });
     });

--- a/src/types/retry-options.ts
+++ b/src/types/retry-options.ts
@@ -6,9 +6,7 @@ import * as t from "io-ts";
 import type { RetryFunction, RequiredRetryOptions } from "got";
 import { codecAssertion, CodecAssertion } from "../utils/codec-assertion";
 
-export interface RetryOptions extends Partial<RequiredRetryOptions> {
-    retries?: number;
-}
+export interface RetryOptions extends Partial<RequiredRetryOptions> {}
 
 const isRetryFunction = (u: unknown): u is RetryFunction => typeof u === "function";
 
@@ -20,7 +18,6 @@ const RetryFunctionCodec = new t.Type<RetryFunction>(
 );
 
 export const RetryOptionsCodec: t.Type<RetryOptions> = t.partial({
-    retries: t.number,
     limit: t.number,
     methods: t.array(
         t.keyof({


### PR DESCRIPTION
- Add default option for readFile to do retry
- Add test to check if retry is successful if API connection is aborted